### PR TITLE
Feature/reduce arguments

### DIFF
--- a/R/applyJobFunction.R
+++ b/R/applyJobFunction.R
@@ -1,11 +1,9 @@
-#' @method applyJobFunction ExperimentRegistry
-#' @export
-applyJobFunction.ExperimentRegistry = function(reg, job, cache) {
-  algo = cache(getAlgorithmFilePath(reg$file.dir, job$algo.id),
-    slot = "algo", parts = "algorithm")$fun
+# internal function to define a wrappers for job/reduce functions 
+# that can have optional arguments job, static and dynamic
+.applyJobWrapper = function(reg, job, cache, algo) {
   algo.use = c("job", "static", "dynamic")
   algo.use = setNames(algo.use %in% names(formals(algo)), algo.use)
-
+  
   # encapsulate the loading into functions for lazy loading
   #
   # IMPORTANT: Note that the order of the messages in the log files can be confusing.
@@ -15,17 +13,28 @@ applyJobFunction.ExperimentRegistry = function(reg, job, cache) {
   parts = getProblemFilePaths(reg$file.dir, job$prob.id)
   static = function() cache(parts["static"], slot = "static", impute = NULL)
   dynamic = function() calcDynamic(reg, job, static(), cache(parts["dynamic"], slot = "dynamic", impute = NULL))
-
+  
   # switch on algo formals and apply algorithm function
   f = switch(sum(c(1L, 2L, 4L)[algo.use]) + 1L,
-    function(...) algo(...),
-    function(...) algo(job = job, ...),
-    function(...) algo(static = static(), ...),
-    function(...) algo(job = job, static = static(), ...),
-    function(...) algo(dynamic = dynamic(), ...),
-    function(...) algo(job = job, dynamic = dynamic(), ...),
-    function(...) algo(static = static(), dynamic = dynamic(), ...),
-    function(...) algo(job = job, static = static(), dynamic = dynamic(), ...))
+          function(...) algo(...),
+          function(...) algo(job = job, ...),
+          function(...) algo(static = static(), ...),
+          function(...) algo(job = job, static = static(), ...),
+          function(...) algo(dynamic = dynamic(), ...),
+          function(...) algo(job = job, dynamic = dynamic(), ...),
+          function(...) algo(static = static(), dynamic = dynamic(), ...),
+          function(...) algo(job = job, static = static(), dynamic = dynamic(), ...))
+  f
+}
+
+#' @method applyJobFunction ExperimentRegistry
+#' @export
+applyJobFunction.ExperimentRegistry = function(reg, job, cache) {
+  algo = cache(getAlgorithmFilePath(reg$file.dir, job$algo.id),
+    slot = "algo", parts = "algorithm")$fun
+
+  # switch on algo formals and apply algorithm function
+  f = .applyJobWrapper(reg, job, cache, algo)
 
   messagef("Applying Algorithm %s ...", job$algo.id)
   do.call(f, job$algo.pars)

--- a/R/applyJobFunction.R
+++ b/R/applyJobFunction.R
@@ -3,7 +3,7 @@
 .applyJobWrapper = function(reg, job, cache, algo) {
   algo.use = c("job", "static", "dynamic")
   algo.use = setNames(algo.use %in% names(formals(algo)), algo.use)
-  
+
   # encapsulate the loading into functions for lazy loading
   #
   # IMPORTANT: Note that the order of the messages in the log files can be confusing.
@@ -13,17 +13,17 @@
   parts = getProblemFilePaths(reg$file.dir, job$prob.id)
   static = function() cache(parts["static"], slot = "static", impute = NULL)
   dynamic = function() calcDynamic(reg, job, static(), cache(parts["dynamic"], slot = "dynamic", impute = NULL))
-  
+
   # switch on algo formals and apply algorithm function
   f = switch(sum(c(1L, 2L, 4L)[algo.use]) + 1L,
-          function(...) algo(...),
-          function(...) algo(job = job, ...),
-          function(...) algo(static = static(), ...),
-          function(...) algo(job = job, static = static(), ...),
-          function(...) algo(dynamic = dynamic(), ...),
-          function(...) algo(job = job, dynamic = dynamic(), ...),
-          function(...) algo(static = static(), dynamic = dynamic(), ...),
-          function(...) algo(job = job, static = static(), dynamic = dynamic(), ...))
+    function(...) algo(...),
+    function(...) algo(job = job, ...),
+    function(...) algo(static = static(), ...),
+    function(...) algo(job = job, static = static(), ...),
+    function(...) algo(dynamic = dynamic(), ...),
+    function(...) algo(job = job, dynamic = dynamic(), ...),
+    function(...) algo(static = static(), dynamic = dynamic(), ...),
+    function(...) algo(job = job, static = static(), dynamic = dynamic(), ...))
   f
 }
 

--- a/R/reduceResultsExperiments.R
+++ b/R/reduceResultsExperiments.R
@@ -85,10 +85,15 @@ reduceResultsExperiments = function(reg, ids, part = NA_character_, fun, ...,
   n = length(ids)
   info("Reducing %i results...", n)
 
+  # setup cache (needed for .applyJobWrapper and loading of static/dynamic) 
+  cache = makeFileCache(use.cache = n > 1L)
+  
   impute = if (with.impute) function(job, res, ...) impute.val else fun
-  getRow = function(j, reg, part, .fun, missing.ok, ...)
+  getRow = function(j, reg, part, .fun, missing.ok, ...){
+    .fun <- .applyJobWrapper(reg, j, cache, .fun)
     c(list(id = j$id, prob = j$prob.id), j$prob.pars, list(algo = j$algo.id), j$algo.pars, list(repl = j$repl),
-      .fun(j, BatchJobs:::getResult(reg, j$id, part, missing.ok), ...))
+      .fun(BatchJobs:::getResult(reg, j$id, part, missing.ok), ...))
+  }
 
   aggr = data.frame()
   ids2 = chunk(ids, chunk.size = block.size, shuffle = FALSE)


### PR DESCRIPTION
I factorised and reused the code used in applyJobFunction.ExperimentRegistry to create a wrapper function that can accommodate optional arguments ``static`` and ``dynamic`` in their signature.

Contrary to what I proposed, these arguments can be placed anywhere in the signature.